### PR TITLE
Use positive look ahead and look behind for string replacements

### DIFF
--- a/soundchanger.js
+++ b/soundchanger.js
@@ -33,13 +33,10 @@ function apply(changes, strings, categories = {}, zeroCharacters = '∅-') {
             console.log(`Failed to apply change "${change}".`)
             continue
         }
-
-        const pattern = `(${before})(${original})(${after})`
-        const lastGroupIndex = pattern.split('(').length - after.split(')').length
-        const replacement = `$1${changeTo}$${lastGroupIndex}`
+        const pattern = `(?<=${before})(${original})(?=${after})`
 
         strings = strings.map(string => {
-            return `#${string}#`.replace(new RegExp(pattern, 'g'), replacement).replace(/#/g, '').trim()
+            return `#${string}#`.replace(new RegExp(pattern, 'g'), changeTo).replace(/#/g, '').trim()
         })
     }
     return strings


### PR DESCRIPTION
Fixes #1.

Input of `apuhi` with change `h>∅/V_V` now correctly outputs `aui` and not `auhi.`